### PR TITLE
Force pseudo-tty allocation

### DIFF
--- a/scripts/copy-to-storage.sh
+++ b/scripts/copy-to-storage.sh
@@ -28,5 +28,5 @@ do
   # For the find command, we can test it by removing the -delete option.
   # find docs: https://manpages.ubuntu.com/manpages/xenial/man1/find.1.html
   /usr/bin/rsync --archive --compress --update --verbose $remote_host:$remote_directory $local_directory && \
-  /usr/bin/ssh $remote_host -t "find \"$remote_directory\" -mindepth 1 -mtime +$delete_older_than_days -type f -name \"$name\" -delete"
+  /usr/bin/ssh $remote_host -tt "find \"$remote_directory\" -mindepth 1 -mtime +$delete_older_than_days -type f -name \"$name\" -delete"
 done

--- a/scripts/copy-to-storage.sh
+++ b/scripts/copy-to-storage.sh
@@ -28,5 +28,5 @@ do
   # For the find command, we can test it by removing the -delete option.
   # find docs: https://manpages.ubuntu.com/manpages/xenial/man1/find.1.html
   /usr/bin/rsync --archive --compress --update --verbose $remote_host:$remote_directory $local_directory && \
-  /usr/bin/ssh $remote_host -tt "find \"$remote_directory\" -mindepth 1 -mtime +$delete_older_than_days -type f -name \"$name\" -delete"
+  /usr/bin/ssh $remote_host "find \"$remote_directory\" -mindepth 1 -mtime +$delete_older_than_days -type f -name \"$name\" -delete"
 done


### PR DESCRIPTION
Do we need the `-t` option at all, if it's running in the background?

https://manpages.ubuntu.com/manpages/xenial/man1/ssh.1.html

```
     -t      Force pseudo-terminal allocation.  This can be used to execute arbitrary screen-
             based programs on a remote machine, which can be very useful, e.g. when implementing
             menu services.  Multiple -t options force tty allocation, even if ssh has no local
             tty.
```