### PR TITLE
Bash quote EOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ end
 This service is designed to run regularly and iterate through the RPIs one at a time, copy the research data, and prevent the storage on the remote devices from filling up. Upon connecting to each remote machine, the process works as follows:
 
 1. Sync all the data files to a specified directory;
-2. Check disk usage, if there isn't much space left then delete files older than *x* minutes;
+2. Check disk usage, if there isn't much space left then delete files older than *x* minutes;
 3. Delete any files older than *x* days;
 4. Wait *n* minutes and start again.
 

--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,12 @@ set -e
 # Install dependencies
 apt install --yes -qqq rsync
 
-# Install service files and scripts
+# Install services
 cp --verbose ./scripts/systemd/*.service /etc/systemd/system/
 cp --verbose ./scripts/systemd/*.timer /etc/systemd/system/
 # Reload the systemd manager configuration. See: https://manpages.ubuntu.com/manpages/xenial/en/man1/systemctl.1.html
 systemctl daemon-reload
+
+# Install scripts
 mkdir --parents /opt/data-pipeline
-cp --verbose ./scripts/copy-to-storage.sh /opt/data-pipeline/copy-to-storage.sh
+cp --verbose ./scripts/*.sh /opt/data-pipeline/

--- a/scripts/check-disk-usage.sh
+++ b/scripts/check-disk-usage.sh
@@ -6,8 +6,10 @@ file_system="/"
 # Percentage disk usage
 threshold=50
 
-if [ "$(df $file_system --output='pcent' | grep --only-matching "[0-9]*")" -gt $threshold ]
-then
+# Get disk usage
+percentage=$(df $file_system --output='pcent' | grep --only-matching "[0-9]*")
+
+if [[ "$percentage" -gt "$threshold" ]]; then
   echo "Full!"
 else
   echo "Okay"

--- a/scripts/check-storage.sh
+++ b/scripts/check-storage.sh
@@ -1,4 +1,4 @@
-!#/bin/bash
+#!/bin/bash
 
 # Check storage on remote machines
 
@@ -9,8 +9,8 @@ raspberry_ids=$(seq 30 35)
 for i in $raspberry_ids
 do
   host="raspberry$i"
-  echo $host
+  echo "$host"
   
   # Display disk usage
-  ssh $host -t "du /home/pi/beephotos -h --summarize && df -hT | grep ext4"
+  ssh "$host" -t "du /home/pi/beephotos -h --summarize && df -hT | grep ext4"
 done

--- a/scripts/copy-to-storage.sh
+++ b/scripts/copy-to-storage.sh
@@ -42,7 +42,7 @@ name="*.np"
 
 percentage=$(df $file_system --output='pcent' | grep --only-matching "[0-9]*")
 # If the disk usage is above the threshold
-if [["$percentage"  -gt "$threshold" ]]; then
+if [[ "$percentage"  -gt "$threshold" ]]; then
   echo "Available disk space low, deleting files older than $delete_older_than_minutes minutes"
   # Delete files older than x minutes
   # For the find command, we can test it by removing the -delete option.

--- a/scripts/copy-to-storage.sh
+++ b/scripts/copy-to-storage.sh
@@ -11,19 +11,10 @@
 remote_directory="/home/pi/beephotos"
 # The directory on this machine
 local_directory="/mnt/san/shared/pml_group/Shared"
-# Delete files older than n days
-delete_older_than_days=7
-name="*.np"
 # Select target machines
 min_rpi_number=1
 max_rpi_number=99
 raspberry_ids="$(seq $min_rpi_number $max_rpi_number)"
-# Check disk usage on remote file system
-file_system="/"
-# Delete data above this percentage disk usage
-threshold=50
-# Delete files older than x minutes
-delete_older_than_minutes=30
 
 # Iterate over all boxes
 # (It'll skip over any machines that it can't connect to because they don't exist or are offline.)
@@ -38,11 +29,21 @@ do
   # Here documents, see https://tldp.org/LDP/abs/html/here-docs.html
   # EOF usage, see https://github.com/koalaman/shellcheck/wiki/SC2087
   /usr/bin/rsync --archive --compress --update --verbose "$remote_host":"$remote_directory" "$local_directory" && \
-  /usr/bin/ssh "$remote_host" "bash -s" << EOF
+  /usr/bin/ssh "$remote_host" "bash -s" <<'EOF'
+# Check disk usage on remote file system
+file_system="/"
+# Delete data above this percentage disk usage
+threshold=50
+# Delete files older than x minutes
+delete_older_than_minutes=30
+# Delete files older than n days
+delete_older_than_days=7
+name="*.np"
+
+percentage=$(df $file_system --output='pcent' | grep --only-matching "[0-9]*")
 # If the disk usage is above the threshold
-if [ $(df $file_system --output='pcent' | grep --only-matching "[0-9]*") -gt $threshold ]
-then
-  echo "Available disk space low"
+if [["$percentage"  -gt "$threshold" ]]; then
+  echo "Available disk space low, deleting files older than $delete_older_than_minutes minutes"
   # Delete files older than x minutes
   # For the find command, we can test it by removing the -delete option.
   # find docs: https://manpages.ubuntu.com/manpages/xenial/man1/find.1.html
@@ -50,6 +51,7 @@ then
   find $remote_directory -mindepth 1 -mmin +$delete_older_than_minutes -type f -name \"$name\" -delete
 else
   # Delete files older than x days
+  echo "Deleting files older than $delete_older_than_days days"
   find $remote_directory -mindepth 1 -mtime +$delete_older_than_days -type f -name \"$name\" -delete
 fi
 EOF

--- a/scripts/copy-to-storage.sh
+++ b/scripts/copy-to-storage.sh
@@ -49,11 +49,11 @@ if [[ "$percentage"  -gt "$threshold" ]]; then
   # For the find command, we can test it by removing the -delete option.
   # find docs: https://manpages.ubuntu.com/manpages/xenial/man1/find.1.html
   # -mtime +n means greater than (-n means less than)
-  find $remote_directory -mindepth 1 -mmin +$delete_older_than_minutes -type f -name \"$name\" -delete
+  find "$remote_directory" -mindepth 1 -mmin +$delete_older_than_minutes -type f -name "$name" -delete
 else
   # Delete files older than x days
   echo "Deleting files older than $delete_older_than_days days"
-  find $remote_directory -mindepth 1 -mtime +$delete_older_than_days -type f -name \"$name\" -delete
+  find "$remote_directory" -mindepth 1 -mtime +$delete_older_than_days -type f -name "$name" -delete
 fi
 EOF
 done

--- a/scripts/copy-to-storage.sh
+++ b/scripts/copy-to-storage.sh
@@ -39,6 +39,7 @@ delete_older_than_minutes=30
 # Delete files older than n days
 delete_older_than_days=7
 name="*.np"
+remote_directory="/home/pi/beephotos"
 
 percentage=$(df $file_system --output='pcent' | grep --only-matching "[0-9]*")
 # If the disk usage is above the threshold


### PR DESCRIPTION
See issue https://github.com/SheffieldMLtracking/data-pipeline/issues/12

Use quotes on the [here document](https://tldp.org/LDP/abs/html/here-docs.html) so that variables are evaluated on the remote machine, not locally

```bash
<<'EOF'
```
